### PR TITLE
Meta: Add vscode debugging config for servers

### DIFF
--- a/annotation-server/.vscode/launch.json
+++ b/annotation-server/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Annotation Server",
+      "args": ["${workspaceFolder}/src/main.ts"],
+      "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
+      "sourceMaps": true,
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector"
+  }
+  ]
+}

--- a/lab-server/.vscode/launch.json
+++ b/lab-server/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Lab Server",
+      "args": ["${workspaceFolder}/src/main.ts"],
+      "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
+      "sourceMaps": true,
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector"
+  }
+  ]
+}


### PR DESCRIPTION
## Changes
<!-- Please summarize your changes: -->
You can now set breakpoints in the annotation server or lab server and debug them in vscode.

## Screenshot of Changes (Optional)
You can debug the servers respectively through this interface:
![grafik](https://user-images.githubusercontent.com/82543715/158172145-0f4e5b68-2add-4109-b92d-d8973f5a5e48.png)
