### PR TITLE
Fix Badge Generator

### DIFF
--- a/other/jest-badges-generator/src/helpers.js
+++ b/other/jest-badges-generator/src/helpers.js
@@ -66,6 +66,8 @@ export const setGitConfig = async () => {
 export const pushBadges = async (branchName, badgeOutputDir) => {
   await exec.exec(`git branch -m ${branchName}`);
   await exec.exec('git add', [badgeOutputDir]);
+  // Discard all changes that were not just staged
+  await exec.exec('git restore .');
   await exec.exec('git commit', ['-m', 'docs: updating coverage badges']);
   await exec.exec('git push');
 };


### PR DESCRIPTION
The Jest badge generator failed with the following output:

![grafik](https://user-images.githubusercontent.com/82543715/159933365-3273067d-d7e7-4fbe-8640-58b98cf29f30.png)

Although i am pretty sure the line I added would fix this, I am not sure if this is just a workaround and the failure is caused by some other faulty behavior that needs to be addressed instead
