### PR TITLE
fix: ensure env files are present during app workflows

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           channel: ${{ env.FLUTTER_CHANNEL }}
           flutter-version: ${{ env.FLUTTER_VERSION }}
+      - run: touch .env
       - run: flutter pub get
       - run: flutter pub run build_runner build
       - run: flutter analyze
@@ -48,6 +49,7 @@ jobs:
         with:
           channel: ${{ env.FLUTTER_CHANNEL }}
           flutter-version: ${{ env.FLUTTER_VERSION }}
+      - run: touch .env
       - run: flutter pub get
       - run: flutter pub run build_runner build
       # TODO(Benjamin-Frost): Enable this when we have tests
@@ -66,6 +68,7 @@ jobs:
         with:
           channel: ${{ env.FLUTTER_CHANNEL }}
           flutter-version: ${{ env.FLUTTER_VERSION }}
+      - run: touch .env
       - run: flutter pub get
       - run: flutter pub run build_runner build
       - run: flutter build apk
@@ -83,6 +86,7 @@ jobs:
         with:
           channel: ${{ env.FLUTTER_CHANNEL }}
           flutter-version: ${{ env.FLUTTER_VERSION }}
+      - run: touch .env
       - run: flutter pub get
       - run: flutter pub run build_runner build
       - run: flutter build ios --release --no-codesign

--- a/app/lib/auth/login/models/lab.dart
+++ b/app/lib/auth/login/models/lab.dart
@@ -12,11 +12,11 @@ final labs = [
   Lab(
     'Illumina Solutions Center Berlin',
     'http://172.20.24.66:28080/auth/realms/pharme',
-    '${dotenv.env['BACKEND_URL']}/api/v1/star-alleles',
+    '${dotenv.get('BACKEND_URL', fallback: 'https://example.com')}/api/v1/star-alleles',
   ),
   Lab(
     'Mount Sinai Hospital (NYC)',
     'http://172.20.24.66:28080/auth/realms/pharme',
-    '${dotenv.env['BACKEND_URL']}/api/v1/star-alleles',
+    '${dotenv.get('BACKEND_URL', fallback: 'https://example.com')}/api/v1/star-alleles',
   )
 ];

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
@@ -5,7 +7,7 @@ import 'common/module.dart';
 import 'common/services.dart';
 
 Future<void> main() async {
-  await dotenv.load();
+  await dotenv.load(mergeWith: Platform.environment);
   await initServices();
   runApp(PharmeApp());
 }


### PR DESCRIPTION
Previously, build and lint jobs would fail due to the environment file
not being present. This change creates an empty `.env` file in the app
root, fixing the issue.

<!-- Please enter the corresponding issue ID: -->

Closes #183 

---

## Changes
<!-- Please summarize your changes: -->
All app-related workflow which require an environment file to be present (ie. linter and build jobs) now create an empty `.env` file as part of the job.