### PR TITLE
deployment health-checks

### DIFF
--- a/.github/workflows/annotation-server.yml
+++ b/.github/workflows/annotation-server.yml
@@ -98,3 +98,4 @@ jobs:
             git reset --hard origin/main
             cd annotation-server
             docker-compose --profile production up --build --force-recreate --no-deps --remove-orphans -d
+            sleep 60; [[ -z "$(docker-compose ps | grep Exit)" ]] || return 1

--- a/.github/workflows/lab-server.yml
+++ b/.github/workflows/lab-server.yml
@@ -112,3 +112,4 @@ jobs:
             git reset --hard origin/main
             cd lab-server
             docker-compose --profile production up --build --force-recreate --no-deps --remove-orphans -d
+            sleep 60; [[ -z "$(docker-compose ps | grep Exit)" ]] || return 1


### PR DESCRIPTION
the `docker-compose` command in the respecitve `deploy` jobs for the
lab/annotation-server does not check for the liveliness of the
containers. As such, a container can crash without this reflecting
negatively in the CI workflow due to the `docker-compose` command always
exiting with code 0. To fix this, we add a crude health check which
exits with non-0 status when a container has status "Fail" after a
60-second grace period.

Closes Issue #211