### PR TITLE
Annotation server image: add Python and adjust compose paths

### DIFF
--- a/annotation-server/Dockerfile
+++ b/annotation-server/Dockerfile
@@ -15,10 +15,15 @@ RUN yarn workspace annotation-server run build
 
 FROM ${BASE_IMAGE}-alpine
 
+RUN apk add --no-cache python3 py3-pip
+
+# mounting directory in docker-compose needs to match WORKDIR
 WORKDIR /app
 
 COPY ./package.json ./yarn.lock ./
 
+COPY ./annotation-server/requirements.txt ./annotation-server/requirements.txt
+RUN pip3 install -r annotation-server/requirements.txt
 COPY ./annotation-server/package.json ./annotation-server/package.json
 COPY ./annotation-server/yarn.lock ./annotation-server/yarn.lock
 RUN yarn workspace annotation-server --production=true --frozen-lockfile install && yarn cache clean

--- a/annotation-server/docker-compose.yml
+++ b/annotation-server/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     env_file: .env
     volumes:
       # mapped folder in the container needs to match the working dir found in the Dockerfile
-      - ./data:/usr/src/app/data:ro
+      - ./data:/app/data:ro
     ports:
       - 8080:3000
     depends_on:


### PR DESCRIPTION
The annotation server needs Python and a Python package at runtime; this PR adds them back in and adjusts volume mount paths so DrugBank data is available. (Also adds comment a comment to hopefully prevent paths mismatching in the future)