### PR TITLE
Setup proper error handling

### DIFF
--- a/annotation-server/src/common/cache-map.ts
+++ b/annotation-server/src/common/cache-map.ts
@@ -1,0 +1,41 @@
+export class CacheMap<Value, RetrieveFailedError> {
+    retrieve: (...keys: string[]) => Promise<Value>;
+    createError: (...keys: string[]) => RetrieveFailedError;
+    validate: (valueOrError: Value | RetrieveFailedError) => Value;
+    cache: Map<string, Value | RetrieveFailedError>;
+
+    constructor(
+        retrieve: (...keys: string[]) => Promise<Value>,
+        createError: (...keys: string[]) => RetrieveFailedError,
+        validate: (valueOrError: Value | RetrieveFailedError) => Value,
+    ) {
+        this.retrieve = retrieve;
+        this.createError = createError;
+        this.validate = validate;
+        this.cache = new Map();
+    }
+
+    private mapKey(keys: string[]) {
+        return keys.join(';');
+    }
+
+    async get(...keys: string[]): Promise<Value> {
+        const key = this.mapKey(keys);
+        if (this.cache.has(key)) {
+            return this.validate(this.cache.get(key));
+        }
+        try {
+            const value = await this.retrieve(...keys);
+            this.cache.set(key, value);
+            return value;
+        } catch {
+            const error = this.createError(...keys);
+            this.cache.set(key, error);
+            throw error;
+        }
+    }
+
+    clear(): void {
+        this.cache.clear();
+    }
+}

--- a/annotation-server/src/common/cache-map.ts
+++ b/annotation-server/src/common/cache-map.ts
@@ -1,17 +1,13 @@
-export class CacheMap<Value, RetrieveFailedError> {
-    retrieve: (...keys: string[]) => Promise<Value>;
-    createError: (...keys: string[]) => RetrieveFailedError;
-    validate: (valueOrError: Value | RetrieveFailedError) => Value;
+export abstract class CacheMap<Value, RetrieveFailedError> {
+    protected abstract retrieve(...keys: string[]): Promise<Value>;
+    protected abstract createError(...keys: string[]): RetrieveFailedError;
+    protected abstract validate(
+        valueOrError: Value | RetrieveFailedError,
+    ): Value;
+
     cache: Map<string, Value | RetrieveFailedError>;
 
-    constructor(
-        retrieve: (...keys: string[]) => Promise<Value>,
-        createError: (...keys: string[]) => RetrieveFailedError,
-        validate: (valueOrError: Value | RetrieveFailedError) => Value,
-    ) {
-        this.retrieve = retrieve;
-        this.createError = createError;
-        this.validate = validate;
+    constructor() {
         this.cache = new Map();
     }
 

--- a/annotation-server/src/gene-phenotypes/gene-phenotypes.service.ts
+++ b/annotation-server/src/gene-phenotypes/gene-phenotypes.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { lastValueFrom } from 'rxjs';
 import { FindOneOptions, Repository } from 'typeorm';
@@ -12,6 +12,8 @@ import { Phenotype } from './entities/phenotype.entity';
 
 @Injectable()
 export class GenePhenotypesService {
+    private readonly logger = new Logger(GenePhenotypesService.name);
+
     constructor(
         private httpService: HttpService,
         @InjectRepository(GeneSymbol)
@@ -29,6 +31,7 @@ export class GenePhenotypesService {
     async fetchGenePhenotypes(): Promise<void> {
         await this.clearAllData();
 
+        this.logger.log('Fetching gene-phenotype combinations from CPIC.');
         const response = this.httpService.get(
             'https://api.cpicpgx.org/v1/diplotype',
             { params: { select: 'lookupkey, generesult' } },
@@ -42,6 +45,9 @@ export class GenePhenotypesService {
         );
 
         this.hashedPhenotypes.clear();
+        this.logger.log(
+            'Successfully saved gene-phenotype combinations to database.',
+        );
     }
 
     private async getGeneSymbolDtos(diplotypeDtos: DiplotypeDto[]) {

--- a/annotation-server/src/gene-phenotypes/gene-phenotypes.service.ts
+++ b/annotation-server/src/gene-phenotypes/gene-phenotypes.service.ts
@@ -107,7 +107,7 @@ export class GenePhenotypesService {
     }
 
     getOneGeneSymbol(options: FindOneOptions<GeneSymbol>): Promise<GeneSymbol> {
-        return this.geneSymbolRepository.findOne(options);
+        return this.geneSymbolRepository.findOneOrFail(options);
     }
 
     getOne(options: FindOneOptions<GenePhenotype>): Promise<GenePhenotype> {

--- a/annotation-server/src/gene-phenotypes/gene-phenotypes.service.ts
+++ b/annotation-server/src/gene-phenotypes/gene-phenotypes.service.ts
@@ -105,6 +105,6 @@ export class GenePhenotypesService {
     }
 
     getOne(options: FindOneOptions<GenePhenotype>): Promise<GenePhenotype> {
-        return this.genePhenotypeRepository.findOne(options);
+        return this.genePhenotypeRepository.findOneOrFail(options);
     }
 }

--- a/annotation-server/src/guidelines/caches/gene-phenotype-caches.ts
+++ b/annotation-server/src/guidelines/caches/gene-phenotype-caches.ts
@@ -1,0 +1,90 @@
+import { ILike } from 'typeorm';
+
+import { GenePhenotype } from '../../gene-phenotypes/entities/gene-phenotype.entity';
+import { GenePhenotypesService } from '../../gene-phenotypes/gene-phenotypes.service';
+import {
+    GuidelineError,
+    GuidelineErrorBlame,
+    GuidelineErrorType,
+} from '../entities/guideline-error.entity';
+import { GuidelineCacheMap } from './guideline-cache';
+
+export class GenePhenotypesByGeneCache extends GuidelineCacheMap<
+    Array<Set<GenePhenotype>>
+> {
+    private genePhenotypesService: GenePhenotypesService;
+    private spreadsheetPhenotypeHeader: Set<string>[];
+
+    constructor(
+        genePhenotypeService: GenePhenotypesService,
+        spreadsheetPhenotypeHeader: Set<string>[],
+    ) {
+        super();
+        this.genePhenotypesService = genePhenotypeService;
+        this.spreadsheetPhenotypeHeader = spreadsheetPhenotypeHeader;
+    }
+
+    protected async retrieve(
+        ...[geneSymbolName]: string[]
+    ): Promise<Set<GenePhenotype>[]> {
+        const geneSymbol = await this.genePhenotypesService.getOneGeneSymbol({
+            where: { name: ILike(geneSymbolName) },
+            relations: [
+                'genePhenotypes',
+                'genePhenotypes.phenotype',
+                'genePhenotypes.geneSymbol',
+            ],
+        });
+        if (!geneSymbol) throw new Error();
+        const genePhenotypes = this.spreadsheetPhenotypeHeader.map(
+            (phenotypes) =>
+                new Set(
+                    geneSymbol.genePhenotypes.filter((genePhenotype) =>
+                        phenotypes.has(
+                            genePhenotype.phenotype.name.toLowerCase(),
+                        ),
+                    ),
+                ),
+        );
+        return genePhenotypes;
+    }
+
+    protected createError(...[geneSymbolName]: string[]): GuidelineError {
+        const error = new GuidelineError();
+        error.type = GuidelineErrorType.GENEPHENOTYPE_NOT_FOUND;
+        error.blame = GuidelineErrorBlame.CPIC;
+        error.context = geneSymbolName;
+        return error;
+    }
+}
+
+export class GenePhenotypesByLookupkeyCache extends GuidelineCacheMap<GenePhenotype> {
+    private genePhenotypesService: GenePhenotypesService;
+
+    constructor(genePhenotypeService: GenePhenotypesService) {
+        super();
+        this.genePhenotypesService = genePhenotypeService;
+    }
+
+    protected async retrieve(
+        ...[geneSymbolName, lookupkey]: string[]
+    ): Promise<GenePhenotype> {
+        return this.genePhenotypesService.getOne({
+            where: {
+                geneSymbol: { name: ILike(geneSymbolName) },
+                phenotype: { lookupkey },
+            },
+            relations: ['phenotype', 'geneSymbol'],
+        });
+    }
+
+    protected createError(
+        ...[geneSymbolName, lookupkey]: string[]
+    ): GuidelineError {
+        const error = new GuidelineError();
+        error.type = GuidelineErrorType.GENEPHENOTYPE_NOT_FOUND;
+        error.blame = GuidelineErrorBlame.CPIC;
+        error.context = `${geneSymbolName}:${lookupkey}`;
+        return error;
+    }
+}

--- a/annotation-server/src/guidelines/caches/gene-phenotype-caches.ts
+++ b/annotation-server/src/guidelines/caches/gene-phenotype-caches.ts
@@ -35,7 +35,6 @@ export class GenePhenotypesByGeneCache extends GuidelineCacheMap<
                 'genePhenotypes.geneSymbol',
             ],
         });
-        if (!geneSymbol) throw new Error();
         const genePhenotypes = this.spreadsheetPhenotypeHeader.map(
             (phenotypes) =>
                 new Set(

--- a/annotation-server/src/guidelines/caches/guideline-cache.ts
+++ b/annotation-server/src/guidelines/caches/guideline-cache.ts
@@ -1,0 +1,12 @@
+import { CacheMap } from '../../common/cache-map';
+import { GuidelineError } from '../entities/guideline-error.entity';
+
+export abstract class GuidelineCacheMap<Value> extends CacheMap<
+    Value,
+    GuidelineError
+> {
+    protected validate(valueOrError: Value | GuidelineError): Value {
+        if (valueOrError instanceof GuidelineError) throw valueOrError;
+        return valueOrError;
+    }
+}

--- a/annotation-server/src/guidelines/caches/medication-caches.ts
+++ b/annotation-server/src/guidelines/caches/medication-caches.ts
@@ -1,0 +1,52 @@
+import { ILike } from 'typeorm';
+
+import { Medication } from '../../medications/medication.entity';
+import { MedicationsService } from '../../medications/medications.service';
+import {
+    GuidelineError,
+    GuidelineErrorBlame,
+    GuidelineErrorType,
+} from '../entities/guideline-error.entity';
+import { GuidelineCacheMap } from './guideline-cache';
+
+export class MedicationByNameCache extends GuidelineCacheMap<Medication> {
+    private medicationsService: MedicationsService;
+
+    constructor(medicationsService: MedicationsService) {
+        super();
+        this.medicationsService = medicationsService;
+    }
+
+    protected retrieve(...[name]: string[]): Promise<Medication> {
+        return this.medicationsService.getOne({ where: { name: ILike(name) } });
+    }
+
+    protected createError(...[name]: string[]): GuidelineError {
+        const error = new GuidelineError();
+        error.type = GuidelineErrorType.MEDICATION_NAME_NOT_FOUND;
+        error.blame = GuidelineErrorBlame.DRUGBANK;
+        error.context = name;
+        return error;
+    }
+}
+
+export class MedicationByRxcuiCache extends GuidelineCacheMap<Medication> {
+    private medicationsService: MedicationsService;
+
+    constructor(medicationsService: MedicationsService) {
+        super();
+        this.medicationsService = medicationsService;
+    }
+
+    protected retrieve(...[rxcui]: string[]): Promise<Medication> {
+        return this.medicationsService.getOne({ where: { rxcui } });
+    }
+
+    protected createError(...[rxcui]: string[]): GuidelineError {
+        const error = new GuidelineError();
+        error.type = GuidelineErrorType.MEDICATION_RXCUI_NOT_FOUND;
+        error.blame = GuidelineErrorBlame.DRUGBANK;
+        error.context = rxcui;
+        return error;
+    }
+}

--- a/annotation-server/src/guidelines/entities/guideline-error.entity.ts
+++ b/annotation-server/src/guidelines/entities/guideline-error.entity.ts
@@ -1,0 +1,38 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+
+import { Guideline } from './guideline.entity';
+
+export enum GuidelineErrorType {
+    MEDICATION_NAME_NOT_FOUND = 'medication_name_not_found',
+    MEDICATION_RXCUI_NOT_FOUND = 'medication_rxcui_not_found',
+    GENEPHENOTYPE_NOT_FOUND = 'genephenotype_not_found',
+    GENE_NOT_FOUND = 'gene_not_found',
+    GUIDELINE_MISSING_FROM_SHEET = 'guideline_missing_from_sheet',
+    GUIDELINE_MISSING_FROM_CPIC = 'guideline_missing_from_cpic',
+}
+
+export enum GuidelineErrorBlame {
+    CPIC = 'cpic',
+    DRUGBANK = 'drugbank',
+    SHEET = 'sheet',
+}
+
+@Entity()
+export class GuidelineError {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ type: 'enum', enum: GuidelineErrorType })
+    type: GuidelineErrorType;
+
+    @Column({ type: 'enum', enum: GuidelineErrorBlame })
+    blame: GuidelineErrorBlame;
+
+    @Column({ nullable: true })
+    context: string;
+
+    @ManyToOne(() => Guideline, (guideline) => guideline.errors, {
+        onDelete: 'CASCADE',
+    })
+    guideline: Guideline;
+}

--- a/annotation-server/src/guidelines/entities/guideline.entity.ts
+++ b/annotation-server/src/guidelines/entities/guideline.entity.ts
@@ -1,8 +1,15 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+    Column,
+    Entity,
+    ManyToOne,
+    OneToMany,
+    PrimaryGeneratedColumn,
+} from 'typeorm';
 
-import { GenePhenotype } from '../gene-phenotypes/entities/gene-phenotype.entity';
-import { Medication } from '../medications/medication.entity';
-import { CpicRecommendationDto } from './dtos/cpic-recommendation.dto';
+import { GenePhenotype } from '../../gene-phenotypes/entities/gene-phenotype.entity';
+import { Medication } from '../../medications/medication.entity';
+import { CpicRecommendationDto } from '../dtos/cpic-recommendation.dto';
+import { GuidelineError } from './guideline-error.entity';
 
 export enum WarningLevel {
     GREEN = 'ok',
@@ -27,6 +34,7 @@ export class Guideline {
             guideline.cpicComment = recommendation.comments;
         guideline.cpicImplication =
             recommendation.implications[genePhenotype.geneSymbol.name];
+        guideline.errors = [];
 
         return guideline;
     }
@@ -75,4 +83,9 @@ export class Guideline {
     public get isComplete(): boolean {
         return !!this.recommendation || !!this.implication;
     }
+
+    @OneToMany(() => GuidelineError, (error) => error.guideline, {
+        cascade: true,
+    })
+    errors: GuidelineError[];
 }

--- a/annotation-server/src/guidelines/guidelines.controller.ts
+++ b/annotation-server/src/guidelines/guidelines.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Post } from '@nestjs/common';
+import { Controller, Get, Post } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
+import { GuidelineError } from './entities/guideline-error.entity';
 import { GuidelinesService } from './guidelines.service';
 
 @ApiTags('Guidelines')
@@ -12,5 +13,11 @@ export class GuidelinesController {
     @Post()
     async fetchGuidelines(): Promise<void> {
         return this.guidelinesService.fetchGuidelines();
+    }
+
+    @ApiOperation({ summary: 'Get all guideline data errors' })
+    @Get('errors')
+    async getErrors(): Promise<GuidelineError[]> {
+        return this.guidelinesService.getAllErrors();
     }
 }

--- a/annotation-server/src/guidelines/guidelines.module.ts
+++ b/annotation-server/src/guidelines/guidelines.module.ts
@@ -4,14 +4,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { GenePhenotypesModule } from '../gene-phenotypes/gene-phenotypes.module';
 import { MedicationsModule } from '../medications/medications.module';
-import { Guideline } from './guideline.entity';
+import { GuidelineError } from './entities/guideline-error.entity';
+import { Guideline } from './entities/guideline.entity';
 import { GuidelinesController } from './guidelines.controller';
 import { GuidelinesService } from './guidelines.service';
 
 @Module({
     imports: [
         HttpModule,
-        TypeOrmModule.forFeature([Guideline]),
+        TypeOrmModule.forFeature([Guideline, GuidelineError]),
         MedicationsModule,
         GenePhenotypesModule,
     ],

--- a/annotation-server/src/guidelines/guidelines.service.ts
+++ b/annotation-server/src/guidelines/guidelines.service.ts
@@ -70,6 +70,7 @@ export class GuidelinesService {
     async complementAndSaveGuidelines(
         guidelines: Map<string, Guideline[]>,
     ): Promise<void> {
+        this.logger.log('Complementing CPIC guidelines with data from sheet.');
         const [
             medications,
             genes,
@@ -182,9 +183,11 @@ export class GuidelinesService {
         this.guidelineErrorRepository.save(Array.from(guidelineErrors));
 
         this.clearCaches();
+        this.logger.log('Successfully saved all valid guidelines.');
     }
 
     async fetchCpicGuidelines(): Promise<Map<string, Guideline[]>> {
+        this.logger.log('Fetching guidelines from CPIC.');
         const response = this.httpService.get(
             'https://api.cpicpgx.org/v1/recommendation',
             {
@@ -237,6 +240,7 @@ export class GuidelinesService {
             }
         }
         this.guidelineErrorRepository.save(Array.from(guidelineErrors));
+        this.logger.log('Successfully fetched guidelines from CPIC.');
         return guidelines;
     }
 

--- a/annotation-server/src/guidelines/guidelines.service.ts
+++ b/annotation-server/src/guidelines/guidelines.service.ts
@@ -300,4 +300,16 @@ export class GuidelinesService {
             this.spreadsheetPhenotypeHeader.length,
         );
     }
+
+    async getAllErrors(): Promise<GuidelineError[]> {
+        return this.guidelineErrorRepository.find({
+            select: {
+                type: true,
+                context: true,
+                blame: true,
+                guideline: { id: true },
+            },
+            relations: ['guideline'],
+        });
+    }
 }

--- a/annotation-server/src/guidelines/guidelines.service.ts
+++ b/annotation-server/src/guidelines/guidelines.service.ts
@@ -6,20 +6,33 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { lastValueFrom } from 'rxjs';
 import { ILike, Repository } from 'typeorm';
 
+import { CacheMap } from '../common/cache-map';
 import { fetchSpreadsheetCells } from '../common/google-sheets';
 import { GenePhenotype } from '../gene-phenotypes/entities/gene-phenotype.entity';
 import { GenePhenotypesService } from '../gene-phenotypes/gene-phenotypes.service';
 import { Medication } from '../medications/medication.entity';
 import { MedicationsService } from '../medications/medications.service';
 import { CpicRecommendationDto } from './dtos/cpic-recommendation.dto';
-import { Guideline, WarningLevel } from './guideline.entity';
+import {
+    GuidelineError,
+    GuidelineErrorBlame,
+    GuidelineErrorType,
+} from './entities/guideline-error.entity';
+import { Guideline, WarningLevel } from './entities/guideline.entity';
 
 @Injectable()
 export class GuidelinesService {
     private readonly logger = new Logger(GuidelinesService.name);
-    private hashedMedicationsByName: Map<string, Medication>;
-    private hashedMedicationsByRxCUI: Map<string, Medication>;
-    private hashedGenePhenotypes: Map<string, Array<Set<GenePhenotype>>>;
+    private medicationsByNameCacher: CacheMap<Medication, GuidelineError>;
+    private medicationsByRxcuiCacher: CacheMap<Medication, GuidelineError>;
+    private genePhenotypesByGeneCacher: CacheMap<
+        Array<Set<GenePhenotype>>,
+        GuidelineError
+    >;
+    private genePhenotypesByLookupkeyCacher: CacheMap<
+        GenePhenotype,
+        GuidelineError
+    >;
     private spreadsheetPhenotypeHeader: Array<Set<string>>;
 
     constructor(
@@ -27,12 +40,108 @@ export class GuidelinesService {
         private httpService: HttpService,
         @InjectRepository(Guideline)
         private guidelinesRepository: Repository<Guideline>,
+        @InjectRepository(GuidelineError)
+        private guidelineErrorRepository: Repository<GuidelineError>,
         private medicationsService: MedicationsService,
         private genePhenotypesService: GenePhenotypesService,
     ) {
-        this.hashedGenePhenotypes = new Map();
-        this.hashedMedicationsByName = new Map();
-        this.hashedMedicationsByRxCUI = new Map();
+        this.medicationsByNameCacher = new CacheMap(
+            (name) =>
+                this.medicationsService.getOne({
+                    where: { name: ILike(name) },
+                }),
+            (name) => {
+                const error = new GuidelineError();
+                error.type = GuidelineErrorType.MEDICATION_NAME_NOT_FOUND;
+                error.blame = GuidelineErrorBlame.DRUGBANK;
+                error.context = name;
+                return error;
+            },
+            (medicationOrError) => {
+                if (medicationOrError instanceof GuidelineError) {
+                    throw medicationOrError;
+                }
+                return medicationOrError;
+            },
+        );
+        this.medicationsByRxcuiCacher = new CacheMap(
+            (rxcui) => this.medicationsService.getOne({ where: { rxcui } }),
+            (rxcui) => {
+                const error = new GuidelineError();
+                error.type = GuidelineErrorType.MEDICATION_RXCUI_NOT_FOUND;
+                error.blame = GuidelineErrorBlame.DRUGBANK;
+                error.context = rxcui;
+                return error;
+            },
+            (medicationOrError) => {
+                if (medicationOrError instanceof GuidelineError) {
+                    throw medicationOrError;
+                }
+                return medicationOrError;
+            },
+        );
+        this.genePhenotypesByGeneCacher = new CacheMap(
+            async (geneSymbolName) => {
+                const geneSymbol =
+                    await this.genePhenotypesService.getOneGeneSymbol({
+                        where: { name: ILike(geneSymbolName) },
+                        relations: [
+                            'genePhenotypes',
+                            'genePhenotypes.phenotype',
+                            'genePhenotypes.geneSymbol',
+                        ],
+                    });
+                if (!geneSymbol) throw new Error();
+                const genePhenotypes = this.spreadsheetPhenotypeHeader.map(
+                    (phenotypes) =>
+                        new Set(
+                            geneSymbol.genePhenotypes.filter((genePhenotype) =>
+                                phenotypes.has(
+                                    genePhenotype.phenotype.name.toLowerCase(),
+                                ),
+                            ),
+                        ),
+                );
+                return genePhenotypes;
+            },
+            (geneSymbolName) => {
+                const error = new GuidelineError();
+                error.type = GuidelineErrorType.GENEPHENOTYPE_NOT_FOUND;
+                error.blame = GuidelineErrorBlame.CPIC;
+                error.context = geneSymbolName;
+                return error;
+            },
+            (valueOrError) => {
+                if (valueOrError instanceof GuidelineError) {
+                    throw valueOrError;
+                }
+                return valueOrError;
+            },
+        );
+        this.genePhenotypesByLookupkeyCacher = new CacheMap(
+            (geneSymbolName, lookupkey) =>
+                this.genePhenotypesService.getOne({
+                    where: {
+                        geneSymbol: { name: ILike(geneSymbolName) },
+                        phenotype: { lookupkey },
+                    },
+                    relations: ['phenotype', 'geneSymbol'],
+                }),
+            (geneSymbolName, lookupkey) => {
+                const error = new GuidelineError();
+                error.type = GuidelineErrorType.GENEPHENOTYPE_NOT_FOUND;
+                error.blame = GuidelineErrorBlame.CPIC;
+                error.context = `${geneSymbolName}: ${lookupkey}`;
+                return error;
+            },
+            (genePhenotypeOrError) => {
+                if (genePhenotypeOrError instanceof GuidelineError) {
+                    throw genePhenotypeOrError;
+                }
+                return genePhenotypeOrError;
+            },
+        );
+
         this.spreadsheetPhenotypeHeader = [];
     }
 
@@ -75,23 +184,29 @@ export class GuidelinesService {
                         .map((phenotype) => phenotype.trim().toLowerCase()),
                 ),
         );
+
+        const guidelineErrors: Set<GuidelineError> = new Set();
         for (let row = 0; row < medications.length; row++) {
             // parse all lines in sheet
             const geneSymbolName = genes[row]?.[0];
             const medicationName = medications[row]?.[0];
-            if (!geneSymbolName || !medicationName) continue;
+            if (!geneSymbolName || !medicationName || !medicationName.value) {
+                continue;
+            }
 
-            const medication = await this.findMedicationByName(
-                medicationName.value,
-            );
-            const genePhenotypes = await this.findGenePhenotypesForGene(
-                geneSymbolName.value,
-            );
-            if (genePhenotypes.length === 0 || !medication) continue;
+            try {
+                const medication = await this.medicationsByNameCacher.get(
+                    medicationName.value,
+                );
+                const genePhenotypes =
+                    await this.genePhenotypesByGeneCacher.get(
+                        geneSymbolName.value,
+                    );
+                if (genePhenotypes.length === 0) continue;
 
-            for (let col = 0; col < implications[row].length; col++) {
-                // supplement guidelines with implications and recommendations from sheet
-                for (const genePhenotype of genePhenotypes[col].values()) {
+                const guidelinesForMedication = guidelines.get(medication.name);
+
+                for (let col = 0; col < implications[row].length; col++) {
                     const implication = implications[row][col].value?.trim();
                     const recommendation =
                         recommendations[row][col].value?.trim();
@@ -103,24 +218,33 @@ export class GuidelinesService {
                             implication,
                             recommendation,
                         )
-                    )
+                    ) {
                         continue;
-
-                    const guidelinesForMedication = guidelines.get(
-                        medication.name,
-                    );
-                    const guidelinesForGenePhenotype =
-                        this.getGuidelinesForGenePhenotype(
-                            medication,
-                            genePhenotype,
-                            guidelinesForMedication,
-                        );
-                    guidelinesForGenePhenotype?.forEach((guideline) => {
-                        guideline.implication = implication;
-                        guideline.recommendation = recommendation;
-                        guideline.warningLevel = warningLevel;
-                    });
+                    }
+                    // supplement guidelines with implications and recommendations from sheet
+                    for (const genePhenotype of genePhenotypes[col].values()) {
+                        try {
+                            const guidelinesForGenePhenotype =
+                                this.getGuidelinesForGenePhenotype(
+                                    medication,
+                                    genePhenotype,
+                                    guidelinesForMedication,
+                                );
+                            guidelinesForGenePhenotype.forEach((guideline) => {
+                                guideline.implication = implication;
+                                guideline.recommendation = recommendation;
+                                guideline.warningLevel = warningLevel;
+                            });
+                        } catch (error) {
+                            guidelineErrors.add(error);
+                        }
+                    }
                 }
+            } catch (error) {
+                if (error instanceof GuidelineError) {
+                    guidelineErrors.add(error);
+                } else throw error;
+                continue;
             }
         }
         const flatGuidelines = Array.from(guidelines.values()).flat();
@@ -129,14 +253,16 @@ export class GuidelinesService {
             (guideline) => !guideline.isComplete,
         );
         for (const incompleteGuideline of incompleteGuidelines) {
-            this.logger.error(
-                `Guideline for ${incompleteGuideline.medication.name} for genephenotype ${incompleteGuideline.genePhenotype.geneSymbol.name}, ${incompleteGuideline.genePhenotype.phenotype.name} is missing from sheet!`,
-            );
+            const error = new GuidelineError();
+            error.type = GuidelineErrorType.GUIDELINE_MISSING_FROM_SHEET;
+            error.blame = GuidelineErrorBlame.SHEET;
+            incompleteGuideline.errors.push(error);
         }
 
         this.guidelinesRepository.save(flatGuidelines);
+        this.guidelineErrorRepository.save(Array.from(guidelineErrors));
 
-        this.clearMaps();
+        this.clearCaches();
     }
 
     async fetchCpicGuidelines(): Promise<Map<string, Guideline[]>> {
@@ -153,33 +279,45 @@ export class GuidelinesService {
         ).data;
 
         const guidelines: Map<string, Guideline[]> = new Map();
+        const guidelineErrors: Set<GuidelineError> = new Set();
 
         for (const cpicRecommendationDto of recommendationDtos) {
             const externalid = cpicRecommendationDto.drugid.split(':');
             if (externalid[0] !== 'RxNorm') continue;
-            const medication = await this.findMedicationByRxNorm(externalid[1]);
-            if (!medication) continue;
-            for (const [geneSymbol, lookupkey] of Object.entries(
-                cpicRecommendationDto.lookupkey,
-            )) {
-                const genePhenotype = await this.findGenePhenotype(
-                    geneSymbol,
-                    lookupkey,
+            try {
+                const medication = await this.medicationsByRxcuiCacher.get(
+                    externalid[1],
                 );
-                if (!genePhenotype) continue;
-                const guideline = Guideline.fromCpicRecommendation(
-                    cpicRecommendationDto,
-                    medication,
-                    genePhenotype,
-                );
+                if (!medication) continue;
+                for (const [geneSymbol, lookupkey] of Object.entries(
+                    cpicRecommendationDto.lookupkey,
+                )) {
+                    const genePhenotype =
+                        await this.genePhenotypesByLookupkeyCacher.get(
+                            geneSymbol,
+                            lookupkey,
+                        );
+                    if (!genePhenotype) continue;
+                    const guideline = Guideline.fromCpicRecommendation(
+                        cpicRecommendationDto,
+                        medication,
+                        genePhenotype,
+                    );
 
-                if (guidelines.has(medication.name)) {
-                    guidelines.get(medication.name).push(guideline);
-                } else {
-                    guidelines.set(medication.name, [guideline]);
+                    if (guidelines.has(medication.name)) {
+                        guidelines.get(medication.name).push(guideline);
+                    } else {
+                        guidelines.set(medication.name, [guideline]);
+                    }
                 }
+            } catch (error) {
+                if (error instanceof GuidelineError) {
+                    guidelineErrors.add(error);
+                } else throw error;
+                continue;
             }
         }
+        this.guidelineErrorRepository.save(Array.from(guidelineErrors));
         return guidelines;
     }
 
@@ -194,110 +332,6 @@ export class GuidelinesService {
         if (red === green && red === blue && blue === green) return null; // any shade of gray or transparent/unset background (undefined)
         this.logger.warn('Sheet cell has unknown color');
         return null;
-    }
-
-    private async findMedicationByName(name: string): Promise<Medication> {
-        if (!name) return null;
-        name = name.trim().toLowerCase();
-        if (this.hashedMedicationsByName.has(name)) {
-            return this.hashedMedicationsByName.get(name);
-        }
-        try {
-            const medication = await this.medicationsService.getOne({
-                where: { name: ILike(name) },
-            });
-
-            this.hashedMedicationsByName.set(name, medication);
-            this.hashedMedicationsByRxCUI.set(medication.rxcui, medication);
-            return medication;
-        } catch (error) {
-            // TODO: consider proper error handling
-            this.logger.error(`Medication ${name} not found in Drugbank data.`);
-            this.hashedMedicationsByName.set(name, null);
-            return null;
-        }
-    }
-
-    private async findMedicationByRxNorm(rxcui: string): Promise<Medication> {
-        if (this.hashedMedicationsByRxCUI.has(rxcui)) {
-            return this.hashedMedicationsByRxCUI.get(rxcui);
-        }
-        try {
-            const medication = await this.medicationsService.getOne({
-                where: {
-                    rxcui,
-                },
-            });
-            this.hashedMedicationsByRxCUI.set(rxcui, medication);
-            this.hashedMedicationsByName.set(medication.name, medication);
-            return medication;
-        } catch (error) {
-            this.logger.error(
-                `Medication with RxCUI ${rxcui} not found in our database.`,
-            );
-            return null;
-        }
-    }
-
-    private async findGenePhenotype(
-        geneSymbolName: string,
-        lookupkey: string,
-    ): Promise<GenePhenotype> {
-        if (!geneSymbolName || !lookupkey) return null;
-        geneSymbolName = geneSymbolName.trim().toLowerCase();
-        try {
-            const genePhenotype = await this.genePhenotypesService.getOne({
-                where: {
-                    geneSymbol: { name: ILike(geneSymbolName) },
-                    phenotype: { lookupkey },
-                },
-                relations: ['phenotype', 'geneSymbol'],
-            });
-            return genePhenotype;
-        } catch (error) {
-            this.logger.error(
-                `GenePhenotype ${geneSymbolName}:${lookupkey} not found in CPIC lookupkeys.`,
-            );
-            return null;
-        }
-    }
-
-    private async findGenePhenotypesForGene(
-        geneSymbolName: string,
-    ): Promise<Array<Set<GenePhenotype>>> {
-        if (!geneSymbolName) return [];
-        geneSymbolName = geneSymbolName.trim().toLowerCase();
-        if (this.hashedGenePhenotypes.has(geneSymbolName)) {
-            return this.hashedGenePhenotypes.get(geneSymbolName);
-        }
-        const geneSymbol = await this.genePhenotypesService.getOneGeneSymbol({
-            where: { name: ILike(geneSymbolName) },
-            relations: [
-                'genePhenotypes',
-                'genePhenotypes.phenotype',
-                'genePhenotypes.geneSymbol',
-            ],
-        });
-        // TODO: consider proper error handling
-        if (!geneSymbol) {
-            this.logger.error(
-                `Gene ${geneSymbolName.toUpperCase()} not found in CPIC lookupkeys.`,
-            );
-            this.hashedGenePhenotypes.set(geneSymbolName, []);
-            return [];
-        }
-        const genePhenotypes = this.spreadsheetPhenotypeHeader.map(
-            (phenotypes) =>
-                new Set(
-                    geneSymbol.genePhenotypes.filter((genePhenotype) =>
-                        phenotypes.has(
-                            genePhenotype.phenotype.name.toLowerCase(),
-                        ),
-                    ),
-                ),
-        );
-        this.hashedGenePhenotypes.set(geneSymbolName, genePhenotypes);
-        return genePhenotypes;
     }
 
     private guidelineTextsAreValid(
@@ -322,23 +356,26 @@ export class GuidelinesService {
                 guidelineForMed.genePhenotype.id === genePhenotype.id,
         );
         if (!guidelinesForGenePhenotype?.length) {
-            this.logger.error(
-                `No matching CPIC guideline was found for ${medication.name} and genephenotype ${genePhenotype.geneSymbol}, ${genePhenotype.phenotype.name}!`,
-            );
-            return null;
+            const error = new GuidelineError();
+            error.type = GuidelineErrorType.GUIDELINE_MISSING_FROM_CPIC;
+            error.blame = GuidelineErrorBlame.CPIC;
+            error.context = `${medication.name}, ${genePhenotype.geneSymbol.name}:${genePhenotype.phenotype.name}`;
+            throw error;
         }
         return guidelinesForGenePhenotype;
     }
 
     async clearAllData(): Promise<void> {
         this.guidelinesRepository.delete({});
-        this.clearMaps();
+        this.guidelineErrorRepository.delete({});
+        this.clearCaches();
     }
 
-    private clearMaps(): void {
-        this.hashedMedicationsByName.clear();
-        this.hashedMedicationsByRxCUI.clear();
-        this.hashedGenePhenotypes.clear();
+    private clearCaches(): void {
+        this.medicationsByNameCacher.clear();
+        this.medicationsByRxcuiCacher.clear();
+        this.genePhenotypesByGeneCacher.clear();
+        this.genePhenotypesByLookupkeyCacher.clear();
         this.spreadsheetPhenotypeHeader = [];
     }
 }

--- a/annotation-server/src/medications/medication.entity.ts
+++ b/annotation-server/src/medications/medication.entity.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 
-import { Guideline } from '../guidelines/guideline.entity';
+import { Guideline } from '../guidelines/entities/guideline.entity';
 import { DrugDto } from './dtos/drugbank.dto';
 
 @Entity()

--- a/annotation-server/src/medications/medications.service.ts
+++ b/annotation-server/src/medications/medications.service.ts
@@ -168,10 +168,10 @@ export class MedicationsService {
             this.logger.error(error);
         });
         proc.stdout.on('data', (data: string) => {
-            this.logger.log(data);
+            this.logger.log(data.toString().replace(/\n\r?/, ''));
         });
         proc.stderr.on('data', (data: string) => {
-            this.logger.error(data);
+            this.logger.error(data.toString().replace(/\n\r?/, ''));
         });
         return new Promise((resolve, reject) => {
             proc.on('exit', (code) => {

--- a/annotation-server/test/app.e2e-spec.ts
+++ b/annotation-server/test/app.e2e-spec.ts
@@ -101,6 +101,14 @@ describe('App (e2e)', () => {
                 );
             }
         });
+
+        it('should verify that data errors have been saved', async () => {
+            const getResponse = await request(app.getHttpServer()).get(
+                '/guidelines/errors',
+            );
+            expect(getResponse.status).toEqual(200);
+            expect(getResponse.body.length).toBeGreaterThan(0);
+        });
     });
 
     afterAll(async () => {

--- a/annotation-server/test/app.e2e-spec.ts
+++ b/annotation-server/test/app.e2e-spec.ts
@@ -2,7 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 
-import { Guideline } from 'src/guidelines/guideline.entity';
+import { Guideline } from 'src/guidelines/entities/guideline.entity';
 
 import { AppModule } from '../src/app.module';
 import { MedicationsService } from '../src/medications/medications.service';


### PR DESCRIPTION
Closes #256

---

## Changes

- saves init data errors to database instead of dumping them to stdout
- introduces endpoint `/guidelines/errors` to get errors
- refactorings
- more verbose logging for `GenePhenotype` and `Guideline` data inits

## Testing Changes

- `POST` to `/init`, enjoy cleaner logging
- check out data errors on `GET` `/guidelines/errors`