### PR TITLE
style: clarify runner stage in dockerfiles

### DIFF
--- a/annotation-server/Dockerfile
+++ b/annotation-server/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN yarn install --frozen-lockfile
 RUN yarn workspace annotation-server run build
 
-FROM ${BASE_IMAGE}-alpine
+FROM ${BASE_IMAGE}-alpine as runner
 
 RUN apk add --no-cache python3 py3-pip
 

--- a/lab-server/Dockerfile
+++ b/lab-server/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN yarn install --frozen-lockfile
 RUN yarn workspace lab-server run build
 
-FROM ${BASE_IMAGE}-alpine
+FROM ${BASE_IMAGE}-alpine as runner
 
 WORKDIR /app
 


### PR DESCRIPTION
No functional change, purely aesthetic. This should make it more clear
at a glance where the runner stage (i.e final image) begins.

closes #282

<!-- Please enter the corresponding issue ID: -->

Closes #

---

## Changes
<!-- Please summarize your changes: -->

## Testing Changes
<!-- Please describe how to test your changes: -->

## Screenshot of Changes (Optional)

<!-- Add this section if you need it.
**Screenshots**
| Description 1  | Description 2  |
| :------------: | :------------: |
| <screenshot 1> | <screenshot 2> |
-->
