### PR TITLE
fix(app): filter user guidelines on medication detail screen

### DIFF
--- a/app/lib/common/pages/medications/medication.dart
+++ b/app/lib/common/pages/medications/medication.dart
@@ -23,8 +23,10 @@ class MedicationPage extends StatelessWidget {
               initial: Container.new,
               error: () => Text(context.l10n.err_generic),
               loading: () => Center(child: CircularProgressIndicator()),
-              loaded: (medication) =>
-                  _buildMedicationsPage(medication, context),
+              loaded: (medication) => _buildMedicationsPage(
+                filterUserGuidelines(medication),
+                context,
+              ),
             ),
           );
         },
@@ -39,21 +41,27 @@ class MedicationPage extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _buildHeader(medication.name, medication.drugclass!),
+        _buildHeader(medication.name, medication.drugclass),
         SizedBox(height: 20),
-        _buildDisclaimer(context),
-        SizedBox(height: 20),
-        _SubHeader(
-          context.l10n.medications_page_header_guideline,
-          tooltip: context.l10n.medications_page_tooltip_guideline,
-        ),
-        SizedBox(height: 12),
-        ClinicalAnnotationCard(medication),
+        if (medication.guidelines.isNotEmpty) ...[
+          _buildDisclaimer(context),
+          SizedBox(height: 20),
+          _SubHeader(
+            context.l10n.medications_page_header_guideline,
+            tooltip: context.l10n.medications_page_tooltip_guideline,
+          ),
+          SizedBox(height: 12),
+          ClinicalAnnotationCard(medication)
+        ] else ...[
+          Text(context.l10n.medications_page_no_guidelines_for_phenotype),
+          SizedBox(height: 12),
+          Text(context.l10n.medications_page_disclaimer),
+        ]
       ],
     );
   }
 
-  Widget _buildHeader(String name, String drugclass) {
+  Widget _buildHeader(String name, String? drugclass) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -68,19 +76,20 @@ class MedicationPage extends StatelessWidget {
             ),
           ],
         ),
-        Container(
-          padding: EdgeInsets.all(6),
-          decoration: BoxDecoration(
-            color: PharmeTheme.onSurfaceColor,
-            borderRadius: BorderRadius.all(Radius.circular(6)),
-          ),
-          child: Text(
-            drugclass,
-            style: PharmeTheme.textTheme.titleMedium!.copyWith(
-              fontWeight: FontWeight.w100,
+        if (drugclass != null)
+          Container(
+            padding: EdgeInsets.all(6),
+            decoration: BoxDecoration(
+              color: PharmeTheme.onSurfaceColor,
+              borderRadius: BorderRadius.all(Radius.circular(6)),
+            ),
+            child: Text(
+              drugclass,
+              style: PharmeTheme.textTheme.titleMedium!.copyWith(
+                fontWeight: FontWeight.w100,
+              ),
             ),
           ),
-        ),
       ],
     );
   }

--- a/app/lib/common/pages/medications/medication.dart
+++ b/app/lib/common/pages/medications/medication.dart
@@ -43,20 +43,17 @@ class MedicationPage extends StatelessWidget {
       children: [
         _buildHeader(medication.name, medication.drugclass),
         SizedBox(height: 20),
-        if (medication.guidelines.isNotEmpty) ...[
-          _buildDisclaimer(context),
-          SizedBox(height: 20),
-          _SubHeader(
-            context.l10n.medications_page_header_guideline,
-            tooltip: context.l10n.medications_page_tooltip_guideline,
-          ),
-          SizedBox(height: 12),
+        _buildDisclaimer(context),
+        SizedBox(height: 20),
+        _SubHeader(
+          context.l10n.medications_page_header_guideline,
+          tooltip: context.l10n.medications_page_tooltip_guideline,
+        ),
+        SizedBox(height: 12),
+        if (medication.guidelines.isNotEmpty)
           ClinicalAnnotationCard(medication)
-        ] else ...[
+        else
           Text(context.l10n.medications_page_no_guidelines_for_phenotype),
-          SizedBox(height: 12),
-          Text(context.l10n.medications_page_disclaimer),
-        ]
       ],
     );
   }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -25,7 +25,7 @@
   "general_continue": "Continue",
   "general_retry": "Retry",
   
-  "medications_page_disclaimer": "This assessment is only based on your genomic data. It does not consider other factors such as weight, age and pre-existing condition",
+  "medications_page_disclaimer": "This assessment is only based on your genomic data. It does not consider other factors such as weight, age and pre-existing conditions.",
   "medications_page_gene_name": "Gene: {geneName}",
   "@medications_page_gene_name": {
     "description": "Name of the Gene.",
@@ -40,6 +40,7 @@
   "medications_page_header_guideline": "Clinical Guideline",
   "medications_page_header_recommendation": "Recommendation",
   "medications_page_info_big_i": "i",
+  "medications_page_no_guidelines_for_phenotype": "No guidelines found matching your genetic profile.",
   "medications_page_sources_cpic_name": "CPIC",
   "medications_page_sources_cpic_description": "Guidelines published by the Clinical Pharmacogenetics Implementation Consortium (CPIC)",
   "medications_page_sources_pharmGkb_name": "PharmGKB",


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->

Closes #348 

The problem wasn't the reports screen, but that the medication details screen didn't filter the guidelines based on the user. The displayed guidelines therefore was the random guideline which was first in the array.

- [x] I have read the [code-style guidelines](https://github.com/hpi-dhc/PharMe/blob/main/docs/FLUTTER_STYLE.md) and confirmed that this PR upholds said guidelines

---

## Changes

<!-- Please summarize your changes: -->
- make drugclass optional
- make guidelines optional
- filter user guidelines to not show random guideline

## Testing Changes

<!-- Please describe how to test your changes: -->
- test whether the information on the details screen matches those in the reports screen
