### PR TITLE
Redirect to cpic from medication screen

### DIFF
--- a/app/lib/common/models/medication/guideline.dart
+++ b/app/lib/common/models/medication/guideline.dart
@@ -17,6 +17,7 @@ class Guideline {
     this.cpicImplication,
     this.cpicClassification,
     this.cpicComment,
+    required this.cpicGuidelineUrl,
     required this.genePhenotype,
   });
   factory Guideline.fromJson(dynamic json) => _$GuidelineFromJson(json);
@@ -46,6 +47,9 @@ class Guideline {
   String? cpicComment;
 
   @HiveField(8)
+  String cpicGuidelineUrl;
+
+  @HiveField(9)
   GenePhenotype genePhenotype;
 
   /// some properties are intentionally omitted, because a difference in them
@@ -60,6 +64,7 @@ class Guideline {
         cpicImplication == other.cpicImplication &&
         cpicClassification == other.cpicClassification &&
         cpicComment == other.cpicComment &&
+        cpicGuidelineUrl == other.cpicGuidelineUrl &&
         genePhenotype == other.genePhenotype;
   }
 
@@ -73,6 +78,7 @@ class Guideline {
       cpicImplication,
       cpicClassification,
       cpicComment,
+      cpicGuidelineUrl,
       genePhenotype,
     );
   }

--- a/app/lib/common/pages/medications/medication.dart
+++ b/app/lib/common/pages/medications/medication.dart
@@ -229,10 +229,9 @@ class ClinicalAnnotationCard extends StatelessWidget {
       ),
       SizedBox(height: 8),
       _buildSourceCard(
-        context.l10n.medications_page_sources_dpwg_name,
-        context.l10n.medications_page_sources_dpwg_description,
-        // TODO(SebastianWagner2): imeplement correct redirects to other sources than PharmGKB, https://github.com/hpi-dhc/PharMe/issues/325
-        () => null,
+        context.l10n.medications_page_sources_cpic_name,
+        context.l10n.medications_page_sources_cpic_description,
+        () => _launchUrl(Uri.parse(medication.guidelines[0].cpicGuidelineUrl)),
       ),
     ]);
   }

--- a/app/lib/common/pages/medications/medication.dart
+++ b/app/lib/common/pages/medications/medication.dart
@@ -234,13 +234,6 @@ class ClinicalAnnotationCard extends StatelessWidget {
         // TODO(SebastianWagner2): imeplement correct redirects to other sources than PharmGKB, https://github.com/hpi-dhc/PharMe/issues/325
         () => null,
       ),
-      SizedBox(height: 8),
-      _buildSourceCard(
-        context.l10n.medications_page_sources_cpic_name,
-        context.l10n.medications_page_sources_cpic_description,
-        // TODO(SebastianWagner2): imeplement correct redirects to other sources than PharmGKB, https://github.com/hpi-dhc/PharMe/issues/325
-        () => null,
-      ),
     ]);
   }
 

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -42,8 +42,6 @@
   "medications_page_info_big_i": "i",
   "medications_page_sources_cpic_name": "CPIC",
   "medications_page_sources_cpic_description": "Guidelines published by the Clinical Pharmacogenetics Implementation Consortium (CPIC)",
-  "medications_page_sources_dpwg_name": "DPWG",
-  "medications_page_sources_dpwg_description": "Guidelines published by the Dutch Pharmacogenetics Working Group (DPWG)",
   "medications_page_sources_pharmGkb_name": "PharmGKB",
   "medications_page_sources_pharmGkb_description": "Curated pharmacogenetic studies for this drug-gene reaction",
   "medications_page_tooltip_classification": "The better the evidence level, the more scientifically accepted is the clinical annotation it refers to. Many studies and good studies mean a high evidence level.",


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->

Closes #325

- [x] I have read the [code-style guidelines](https://github.com/hpi-dhc/PharMe/blob/main/docs/FLUTTER_STYLE.md) and confirmed that this PR upholds said guidelines

- Also deleted DPWG info button from medications details screen