### PR TITLE
fix: disable cleartext traffic on android emulator

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -1,11 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.hpi.pharme">
    <uses-permission android:name="android.permission.INTERNET" />
+   <!-- If you wish to run the app on a local setup (i.e local lab server, annotation server,
+        etc.) set the parameter 'android:usesCleartextTraffic' to 'true' -->
    <application
         android:label="PharMe"
         android:icon="@mipmap/launcher_icon"
-        android:usesCleartextTraffic="true">
-        <!--TODO Delete line above when in production, http requests-->
+        android:usesCleartextTraffic="false"
+   >
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"


### PR DESCRIPTION
closes #95

<!-- Please enter the corresponding issue ID: -->

Closes #

- [x] I have read the [code-style guidelines](https://github.com/hpi-dhc/PharMe/blob/main/docs/FLUTTER_STYLE.md) and confirmed that this PR upholds said guidelines

---

## Changes

<!-- Please summarize your changes: -->
Disables cleartext traffic by default on android emulator.

## Testing Changes

<!-- Please describe how to test your changes: -->

## Screenshot of Changes (Optional)

<!-- Add this section if you need it.
**Screenshots**
| Description 1  | Description 2  |
| :------------: | :------------: |
| <screenshot 1> | <screenshot 2> |
-->
