### PR TITLE
fix(app): allow localhost addresses

### DIFF
--- a/app/lib/common/pages/medications/cubit.dart
+++ b/app/lib/common/pages/medications/cubit.dart
@@ -17,7 +17,7 @@ class MedicationsCubit extends Cubit<MedicationsState> {
 
   Future<void> loadMedications() async {
     emit(MedicationsState.loading());
-    final isOnline = await hasConnectionTo(annotationServerUrl.authority);
+    final isOnline = await hasConnectionTo(annotationServerUrl.host);
     if (!isOnline) {
       _findCachedMedication(_id);
       return;

--- a/app/lib/reports/pages/cubit.dart
+++ b/app/lib/reports/pages/cubit.dart
@@ -16,12 +16,12 @@ class ReportsCubit extends Cubit<ReportsState> {
     final requestUri = annotationServerUrl.replace(
       path: 'api/v1/medications',
       queryParameters: {
-          'withGuidelines': 'true',
-          'getGuidelines': 'true',
+        'withGuidelines': 'true',
+        'getGuidelines': 'true',
       },
     );
 
-    final isOnline = await hasConnectionTo(requestUri.authority);
+    final isOnline = await hasConnectionTo(requestUri.host);
     if (!isOnline) {
       emit(
         ReportsState.loaded(

--- a/app/lib/search/pages/cubit.dart
+++ b/app/lib/search/pages/cubit.dart
@@ -36,7 +36,7 @@ class SearchCubit extends Cubit<SearchState> {
         );
         emit(SearchState.loading());
 
-        final isOnline = await hasConnectionTo(requestUri.authority);
+        final isOnline = await hasConnectionTo(requestUri.host);
         if (!isOnline) {
           _findInCachedMedications(value);
           return;


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->

Closes #385 

- [x] I have read the [code-style guidelines](https://github.com/hpi-dhc/PharMe/blob/main/docs/FLUTTER_STYLE.md) and confirmed that this PR upholds said guidelines

---

## Changes

<!-- Please summarize your changes: -->
- you can now use the local annotation server and lab server without having to change any code, because `hasConnectionTo` now evaluates to `true`.

## Testing Changes

<!-- Please describe how to test your changes: -->
- use local annotation server in `constants.dart` and test, if you can search for medications in the app
