### PR TITLE
build(anni): add Git config for backupper to .env

### DIFF
--- a/anni/backupper/.env.example
+++ b/anni/backupper/.env.example
@@ -1,5 +1,8 @@
-# Token to allow pushing to the private backup repo; see README
+# URL and token to allow pushing to the private backup repo; see README
+GITHUB_URL=
 GITHUB_OAUTH=
+GITHUB_USER_EMAIL=
+GITHUB_USER_NAME=
 
 # For use with docker compose profiles `production` and `with-backupper`, you
 # can leave these values as they are!

--- a/anni/backupper/Dockerfile
+++ b/anni/backupper/Dockerfile
@@ -4,8 +4,6 @@ RUN apk add --no-cache curl
 RUN apk add --no-cache jq
 
 RUN apk add --no-cache git
-RUN git config --global user.email "pharme@lists.myhpi.de"
-RUN git config --global user.name "Anni Backupper"
 
 COPY ./run.sh /etc/periodic/15min/run-backupper.sh
 RUN chmod +x /etc/periodic/15min/run-backupper.sh

--- a/anni/backupper/README.md
+++ b/anni/backupper/README.md
@@ -3,9 +3,9 @@
 This is the second degree of backups & version control for Anni to be used
 alongside its own native version control.
 
-The Backupper fetches a backup from Anni every 15 minutes and commits it to the
-[PharMe-Data](https://github.com/hpi-dhc/PharMe-Data) repository. This ensures
-that data can be restored even if Anni's database is lost.
+The Backupper fetches a backup from Anni every 15 minutes and commits it to a
+Git repository. This ensures that data can be restored even if Anni's database
+is lost.
 
 ## Setup
 

--- a/anni/backupper/run.sh
+++ b/anni/backupper/run.sh
@@ -4,8 +4,11 @@ ROOT_DIR=$(dirname $(realpath $0))
 
 . $ROOT_DIR/.env
 
+git config user.email $GITHUB_USER_EMAIL
+git config user.name $GITHUB_USER_NAME
+
 test -d $BACKUP_DIR \
-    || git clone https://oauth2:$GITHUB_OAUTH@github.com/hpi-dhc/PharMe-Data $BACKUP_DIR
+    || git clone https://oauth2:$GITHUB_OAUTH@$GITHUB_URL $BACKUP_DIR
 
 cd $BACKUP_DIR
 

--- a/anni/docker-compose.yaml
+++ b/anni/docker-compose.yaml
@@ -35,8 +35,7 @@ services:
 
   backupper:
     build:
-      dockerfile: ./anni/backupper/Dockerfile
-      context: ../
+      context: ./anni/backupper
     env_file:
       - backupper/.env
     depends_on:


### PR DESCRIPTION
## Changes

Git credentials for the backupper repository are now defined in the `.env` file.