### PR TITLE
Issue/601 use phenotypes from cpic

### DIFF
--- a/anni/src/common/cpic-api.ts
+++ b/anni/src/common/cpic-api.ts
@@ -4,7 +4,8 @@ export type CpicRecommendation = {
     version: number;
 
     drug: { name: string };
-    lookupkey: { [key: string]: string }; // gene-symbol: phenotype
+    lookupkey: { [key: string]: string }; // gene-symbol: phenotype-description (can be activity score)
+    phenotypes: { [key: string]: string }; // gene-symbol: phenotype (can be empty)
 
     guideline: { name: string; url: string };
     implications: { [key: string]: string }; // gene-symbol: implication

--- a/anni/src/common/cpic-api.ts
+++ b/anni/src/common/cpic-api.ts
@@ -15,5 +15,5 @@ export type CpicRecommendation = {
 export const cpicRecommendationsURL =
     'https://api.cpicpgx.org/v1/recommendation';
 export const cpicRecommendationsParams = {
-    select: 'id,drugid,version,drug(name),lookupkey,guideline(name,url),implications,drugrecommendation,comments',
+    select: 'id,drugid,version,drug(name),lookupkey,phenotypes,guideline(name,url),implications,drugrecommendation,comments',
 };

--- a/anni/src/database/helpers/cpic-constructors.ts
+++ b/anni/src/database/helpers/cpic-constructors.ts
@@ -6,14 +6,20 @@ function guidelineFromRecommendation(
     recommendation: CpicRecommendation,
     source: string,
 ): IGuideline_Any {
+    function makeStringValuesLists(object: { [key: string]: string }): {
+        [key: string]: [string];
+    } {
+        const emptyNewList = new Object() as { [key: string]: [string] };
+        return object != undefined
+            ? Object.entries(object).reduce((reducedObject, [key, value]) => {
+                  reducedObject[key] = [value];
+                  return reducedObject;
+              }, emptyNewList)
+            : emptyNewList;
+    }
     return {
-        lookupkey: Object.entries(recommendation.lookupkey).reduce(
-            (lookupkey, [gene, phenotype]) => {
-                lookupkey[gene] = [phenotype];
-                return lookupkey;
-            },
-            new Object() as { [key: string]: [string] },
-        ),
+        lookupkey: makeStringValuesLists(recommendation.lookupkey),
+        phenotypes: makeStringValuesLists(recommendation.phenotypes),
         externalData: [
             {
                 source,

--- a/anni/src/database/helpers/cpic-constructors.ts
+++ b/anni/src/database/helpers/cpic-constructors.ts
@@ -6,20 +6,20 @@ function guidelineFromRecommendation(
     recommendation: CpicRecommendation,
     source: string,
 ): IGuideline_Any {
-    function makeStringValuesLists(object: { [key: string]: string }): {
-        [key: string]: [string];
-    } {
-        const emptyNewList = new Object() as { [key: string]: [string] };
-        return object != undefined
-            ? Object.entries(object).reduce((reducedObject, [key, value]) => {
-                  reducedObject[key] = [value];
-                  return reducedObject;
-              }, emptyNewList)
-            : emptyNewList;
-    }
+    // make lookupkey and phenotype lists for merging later and add
+    // lookupkeys as phenotypes if phenotypes are missing
+    const lookupkey = new Object() as { [key: string]: [string] };
+    const phenotypes = new Object() as { [key: string]: [string] };
+    Object.keys(recommendation.lookupkey).forEach((gene) => {
+        lookupkey[gene] = [recommendation.lookupkey[gene]];
+        phenotypes[gene] =
+            gene in recommendation.phenotypes
+                ? [recommendation.phenotypes[gene]]
+                : [recommendation.lookupkey[gene]];
+    });
     return {
-        lookupkey: makeStringValuesLists(recommendation.lookupkey),
-        phenotypes: makeStringValuesLists(recommendation.phenotypes),
+        lookupkey,
+        phenotypes,
         externalData: [
             {
                 source,
@@ -61,13 +61,7 @@ function guidelineKey(recommendation: CpicRecommendation) {
 // activity scores)
 function phenotypeKey(guideline: IGuideline_Any): string {
     return Object.keys(guideline.lookupkey)
-        .map((gene) => {
-            let phenotype = guideline.lookupkey[gene];
-            if (gene in guideline.phenotypes) {
-                phenotype = guideline.phenotypes[gene];
-            }
-            return `${gene}${phenotype}`;
-        })
+        .map((gene) => `${gene}${guideline.phenotypes[gene]}`)
         .join('');
 }
 

--- a/anni/src/database/helpers/guideline-data.ts
+++ b/anni/src/database/helpers/guideline-data.ts
@@ -19,17 +19,19 @@ export function guidelineDescription(
     guideline: IGuideline_Any,
 ): Array<{ gene: string; description: string }> {
     return Object.keys(guideline.lookupkey).map((gene) => {
-        const lookupkeys = guideline.lookupkey[gene];
-        let description = Array.from(new Set(lookupkeys)).join('/');
-        if ('phenotypes' in guideline && gene in guideline.phenotypes) {
-            const phenotypes = Array.from(
-                new Set(guideline.phenotypes[gene]),
-            ).join('/');
-            if (phenotypes != description) {
-                description = `${phenotypes} (${description})`;
-            }
+        function descriptionString(descriptionParts: [string]): string {
+            return Array.from(new Set(descriptionParts)).join('/');
         }
-
+        const phenotypeDescriptionString = descriptionString(
+            guideline.phenotypes[gene],
+        );
+        const lookupkeyDescriptionString = descriptionString(
+            guideline.lookupkey[gene],
+        );
+        const description =
+            phenotypeDescriptionString != lookupkeyDescriptionString
+                ? `${phenotypeDescriptionString} (${lookupkeyDescriptionString})`
+                : phenotypeDescriptionString;
         return {
             gene,
             description,

--- a/anni/src/database/helpers/guideline-data.ts
+++ b/anni/src/database/helpers/guideline-data.ts
@@ -1,5 +1,5 @@
-import { IGuideline_Any } from '../models/Guideline';
 import { CurationState } from './annotations';
+import { IGuideline_Any } from '../models/Guideline';
 
 export function guidelineCurationState(
     guideline: IGuideline_Any,
@@ -18,10 +18,21 @@ export function guidelineCurationState(
 export function guidelineDescription(
     guideline: IGuideline_Any,
 ): Array<{ gene: string; description: string }> {
-    return Object.entries(guideline.lookupkey).map(([gene, description]) => {
+    return Object.keys(guideline.lookupkey).map((gene) => {
+        const lookupkeys = guideline.lookupkey[gene];
+        let description = Array.from(new Set(lookupkeys)).join('/');
+        if ('phenotypes' in guideline && gene in guideline.phenotypes) {
+            const phenotypes = Array.from(
+                new Set(guideline.phenotypes[gene]),
+            ).join('/');
+            if (phenotypes != description) {
+                description = `${phenotypes} (${description})`;
+            }
+        }
+
         return {
             gene,
-            description: Array.from(new Set(description)).join('/'),
+            description,
         };
     });
 }

--- a/anni/src/database/models/Guideline.ts
+++ b/anni/src/database/models/Guideline.ts
@@ -55,7 +55,7 @@ export type IGuideline_Resolved = IGuideline<string, OptionalId>;
 
 const { schema, makeModel } = versionedModel<IGuideline_DB>('Guideline', {
     lookupkey: { type: {}, required: true },
-    phenotypes: { type: {}, required: false },
+    phenotypes: { type: {}, required: true },
     externalData: {
         type: [
             {

--- a/anni/src/database/models/Guideline.ts
+++ b/anni/src/database/models/Guideline.ts
@@ -29,6 +29,7 @@ export interface IGuideline<
         }
     > {
     lookupkey: { [key: string]: [string] }; // gene-symbol: phenotype-description
+    phenotypes: { [key: string]: [string] }; // gene-symbol: phenotype
     externalData: Array<{
         source: string;
         recommendationId?: number;
@@ -54,6 +55,7 @@ export type IGuideline_Resolved = IGuideline<string, OptionalId>;
 
 const { schema, makeModel } = versionedModel<IGuideline_DB>('Guideline', {
     lookupkey: { type: {}, required: true },
+    phenotypes: { type: {}, required: false },
     externalData: {
         type: [
             {


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->

Closes #601 

## Changes

* Get phenotype information from external sources
* Use phenotype information instead of lookup key, if present
* Show lookup keys in Anni if different from phenotypes (e.g., for activity scores)
