### PR TITLE
feat(#637): show unknown guidelines as green

### DIFF
--- a/app/lib/common/constants.dart
+++ b/app/lib/common/constants.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 Uri anniUrl([String slug = '']) =>
@@ -22,7 +21,6 @@ final cpicMaxCacheTime = Duration(days: 90);
 const maxCachedDrugs = 10;
 const cpicLookupUrl =
     'https://api.cpicpgx.org/v1/diplotype?select=genesymbol,diplotype,generesult,lookupkey';
-const indeterminateIcon = Icons.help_outline_rounded;
 
 const drugInteractionIndicator = '*';
 const drugInteractionIndicatorName = 'asterisk';

--- a/app/lib/common/models/drug/drug.dart
+++ b/app/lib/common/models/drug/drug.dart
@@ -2,6 +2,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hive/hive.dart';
 
 import '../../module.dart';
+import '../../utilities/guideline_utils.dart';
 
 part 'drug.g.dart';
 
@@ -92,8 +93,9 @@ extension DrugWithUserGuideline on Drug {
 extension CriticalDrugs on List<Drug> {
   List<Drug> filterCritical() {
     return filter((drug) {
-      final warningLevel = drug.userGuideline()?.annotations.warningLevel;
-      return warningLevel != null && warningLevel != WarningLevel.green;
+      final warningLevel = getWarningLevel(drug.userGuideline());
+      return warningLevel != WarningLevel.none &&
+        warningLevel != WarningLevel.green;
     }).toList();
   }
 }

--- a/app/lib/common/models/drug/warning_level.dart
+++ b/app/lib/common/models/drug/warning_level.dart
@@ -20,6 +20,7 @@ extension WarningLevelIcon on WarningLevel {
     WarningLevel.red.name: Icons.dangerous_rounded,
     WarningLevel.yellow.name: Icons.warning_rounded,
     WarningLevel.green.name: Icons.check_circle_rounded,
+    WarningLevel.none.name: Icons.help_outline_rounded,
   };
 
   IconData get icon => WarningLevelIcon._iconMap[name]!;
@@ -30,7 +31,7 @@ extension WarningLevelSeverity on WarningLevel {
     WarningLevel.red.name: 2,
     WarningLevel.yellow.name: 1,
     WarningLevel.green.name: 0,
-    WarningLevel.none.name: -1,
+    WarningLevel.none.name: 0,
   };
   int get severity => WarningLevelSeverity._severityMap[name]!;
 }

--- a/app/lib/common/pages/drug/widgets/annotation_cards/guideline.dart
+++ b/app/lib/common/pages/drug/widgets/annotation_cards/guideline.dart
@@ -1,6 +1,7 @@
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../module.dart';
+import '../../../../utilities/guideline_utils.dart';
 import '../sub_header.dart';
 
 class GuidelineAnnotationCard extends StatelessWidget {
@@ -35,7 +36,7 @@ class GuidelineAnnotationCard extends StatelessWidget {
   }
 
   Widget _buildCard(BuildContext context) {
-    final warningLevel = guideline?.annotations.warningLevel;
+    final warningLevel = getWarningLevel(guideline);
     final upperCardText = guideline?.annotations.implication ??
       context.l10n.drugs_page_no_guidelines_for_phenotype_implication(
         drug!.name
@@ -47,14 +48,13 @@ class GuidelineAnnotationCard extends StatelessWidget {
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
         ),
-        color: warningLevel?.color ?? PharMeTheme.indeterminateColor,
+        color: warningLevel.color,
         child: Padding(
             padding: EdgeInsets.all(12),
             child:
                 Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
               Row(children: [
-                Icon(warningLevel?.icon ?? indeterminateIcon,
-                    color: PharMeTheme.onSurfaceText),
+                Icon(warningLevel.icon, color: PharMeTheme.onSurfaceText),
                 SizedBox(width: 12),
                 Flexible(
                   child: Text(

--- a/app/lib/common/theme.dart
+++ b/app/lib/common/theme.dart
@@ -67,7 +67,6 @@ class PharMeTheme {
 
   static const surfaceColor = Colors.white;
   static const onSurfaceColor = Color(0xffe5e5e5);
-  static const indeterminateColor = onSurfaceColor;
   static const onSurfaceText = Color(0xff444648);
   static const backgroundColor = Colors.white;
   static const errorColor = Color(0xccf52a2a);
@@ -104,6 +103,7 @@ extension WarningLevelColor on WarningLevel {
     WarningLevel.red.name: Color(0xffffafaf),
     WarningLevel.yellow.name: Color(0xffffebcc),
     WarningLevel.green.name: Color(0xffcfe8cf),
+    WarningLevel.none.name: Color(0xffcfe8cf),
   };
 
   Color get color => WarningLevelColor._colorMap[name]!;

--- a/app/lib/common/utilities/guideline_utils.dart
+++ b/app/lib/common/utilities/guideline_utils.dart
@@ -1,0 +1,4 @@
+import '../module.dart';
+
+WarningLevel getWarningLevel(Guideline? guideline) =>
+  guideline?.annotations.warningLevel ?? WarningLevel.none;

--- a/app/lib/common/widgets/drug_list/drug_items/drug_cards.dart
+++ b/app/lib/common/widgets/drug_list/drug_items/drug_cards.dart
@@ -1,4 +1,5 @@
 import '../../../module.dart';
+import '../../../utilities/guideline_utils.dart';
 import 'utils.dart';
 
 List<Widget> buildDrugCards(
@@ -9,11 +10,8 @@ List<Widget> buildDrugCards(
     bool showDrugInteractionIndicator = false,
   }
 ) {
-  int warningLevelSeverity(Drug drug) {
-      final warningLevel = drug.userGuideline()?.annotations.warningLevel
-        ?? WarningLevel.none;
-      return warningLevel.severity;
-    }
+  int warningLevelSeverity(Drug drug) =>
+    getWarningLevel(drug.userGuideline()).severity;
   drugs.sort((drugA, drugB) {
     final warningLevelComparison = -warningLevelSeverity(drugA)
       .compareTo(warningLevelSeverity(drugB));
@@ -45,7 +43,7 @@ class DrugCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final warningLevel = drug.userGuideline()?.annotations.warningLevel;
+    final warningLevel = getWarningLevel(drug.userGuideline());
     final drugName = formatDrugName(drug, showDrugInteractionIndicator);
     return Padding(
       padding: EdgeInsets.symmetric(vertical: PharMeTheme.smallSpace / 2),
@@ -53,7 +51,7 @@ class DrugCard extends StatelessWidget {
         onTap: onTap,
         padding: EdgeInsets.all(8),
         radius: 16,
-        color: warningLevel?.color ?? PharMeTheme.indeterminateColor,
+        color: warningLevel.color,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
@@ -62,7 +60,7 @@ class DrugCard extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Row(children: [
-                    Icon(warningLevel?.icon ?? indeterminateIcon),
+                    Icon(warningLevel.icon),
                     SizedBox(width: 4),
                     Text(
                       drugName,

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -30,7 +30,7 @@
   "search_page_filter_green": "Show green warning level",
   "search_page_filter_yellow": "Show yellow warning level",
   "search_page_filter_red": "Show red warning level",
-  "search_page_filter_gray": "Show gray warning level",
+  "search_page_filter_gray": "Show drugs without guidelines",
   "search_page_indicator_explanation": "Taking drugs with an {indicatorName} ({indicator}) can influence your results for other drugs",
   "@search_page_indicator_explanation": {
     "description": "Explanation of drug-drug interaction indicators",
@@ -111,7 +111,7 @@
         }
     }
   },
-  "drugs_page_no_guidelines_for_phenotype_recommendation": "No recommendation can be made at this time. Consult your pharmacist or doctor for more information.",
+  "drugs_page_no_guidelines_for_phenotype_recommendation": "Clinical dosing applies; no pharmacogenetic recommendation can be made at this time. Consult your pharmacist or doctor for more information.",
   "drugs_page_sources_description": "Tap here to review the corresponding guideline published by {source}",
   "@drugs_page_sources_description": {
       "description": "Instructions to open external source",


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->

Closes #637

## Changes

* Show unknown warning as green, not gray
* Refactoring: introduce method to get warning level from guideline or `WarningLevel.none`, if guideline is ´null´